### PR TITLE
feat: ✨ move from google analytics to umami

### DIFF
--- a/docs/cookiepolicy.md
+++ b/docs/cookiepolicy.md
@@ -8,46 +8,17 @@ image: https://docs.sodaforsparc.io/thumbnails/base/cookiepolicy.png
 
 ## What Are Cookies?
 
-As is common practice with almost all professional websites this site uses cookies, which are tiny files that are downloaded to your computer, to improve your experience. This page describes what information they gather, how we use it and why we sometimes need to store these cookies. We will also share how you can prevent these cookies from being stored however this may downgrade or 'break' certain elements of the sites functionality.
+A cookie is a file that is downloaded to a device (computer or mobile phone) when accessing certain web pages. Cookies allow a web page, among other things, to store and retrieve information about the browsing habits of a user or a computer and, depending on the information they contain and the way they use their equipment, they can be used to recognize to user.
 
 For more information, please visit [AllAboutCookies.org](https://www.allaboutcookies.org/).
 
 ## How We Use Cookies
 
-We use cookies for a variety of reasons detailed below. Unfortunately in most cases there are no industry standard options for disabling cookies without completely disabling the functionality and features they add to this site. It is recommended that you leave on all cookies if you are not sure whether you need them or not in case they are used to provide a service that you use.
+We do not use third-party cookies or send any information to third-parties. We do collect website usage information via the privacy focused, self hosted and open source [Umami](https://umami.is/) platform. Umami lets us gather the data you need while respecting your privacy. Umami does not collect any personal information, does not use cookies, does not track users across websites, and is GDPR compliant. All data collected is anonymized, making it impossible to identify any individual user. To see exactly what information we collect you can preview our public dashboard [here](https://umami.fairdataihub.org/share/IgtWDN0v/docs.sodaforsparc.io).
 
-## Disabling Cookies
-
-At the moment we do not have the functionality to disable cookies from the website. In order to prevent any tracking by third party analysis and measurement tools we use, please follow the steps provided below for your specific browser.
-
-## Find out how to manage cookies on popular browsers
-
-- [Google Chrome](https://support.google.com/accounts/answer/61416)
-- [Mozilla Firefox](https://support.mozilla.org/en-US/kb/enable-and-disable-cookies-website-preferences)
-- [Apple Safari](https://support.apple.com/en-gb/guide/safari/sfri11471/mac)
-- [Microsoft Edge](https://support.microsoft.com/sr-latn-rs/help/4468242/microsoft-edge-browsing-data-and-privacy-microsoft-privacy)
-- [Microsoft Internet Explorer](https://support.microsoft.com/en-gb/help/17442/windows-internet-explorer-delete-manage-cookies)
-- [Opera](https://help.opera.com/en/latest/web-preferences/#cookies)
-
-To find information relating to other browsers, visit the browser developer's website.
-
-To opt-out of being tracked by Google Analytics across all websites, visit http://tools.google.com/dlpage/gaoptout
-
-You can also visit the trade body representing these advertising platforms for more information: [Network Advertising Initiative](https://www.networkadvertising.org/choices/;).
+## Additional Information
 
 When you access third party sites on our Sites, or when you are reading integration or social media links, cookies can be created by the companies disseminating these links. These third parties may be able to use cookies in the context of Fair Data Innovations Hub's Services (partners or other third parties supplying content or services available on the Fair Data Innovations Hub site) and are responsible for the cookies they install, and it is their conditions on cookies which apply. For more information, you are advised to check the cookie policy directly on these third-party sites concerning their use of cookies.
-
-## The Cookies We Set
-
-Site preferences cookies - In order to provide you with a great experience on this site we provide the functionality to set your preferences for how this site runs when you use it. In order to remember your preferences we need to set cookies so that this information can be called whenever you interact with a page is affected by your preferences.
-##Third Party Cookies
-In some special cases we also use cookies provided by trusted third parties. The following section details which third party cookies you might encounter through this site.
-
-- This site uses Google Analytics which is one of the most widespread and trusted analytics solution on the web for helping us to understand how you use the site and ways that we can improve - your experience. These cookies may track things such as how long you spend on the site and the pages that you visit so we can continue to produce engaging content. For more information on Google Analytics cookies, see the official [Google Analytics](https://policies.google.com/privacy?hl=en-US) page.
-- Third party analytics are used to track and measure usage of this site so that we can continue to produce engaging content. These cookies may track things such as how long you spend on the - site or pages you visit which helps us to understand how we can improve the site for you.
-- From time to time we test new features and make subtle changes to the way that the site is delivered. When we are still testing new features these cookies may be used to ensure that you - receive a consistent experience whilst on the site whilst ensuring we understand which optimisations our users appreciate the most.
-- As we sell products it's important for us to understand statistics about how many of the visitors to our site actually make a purchase and as such this is the kind of data that these cookies - will track. This is important to you as it means that we can accurately make business predictions that allow us to monitor our advertising and product costs to ensure the best possible price.
-- We also use social media buttons and/or plugins on this site that allow you to connect with your social network in various ways. For these to work the following social media sites including - Twitter, Facebook, Instagram, etc., will set cookies through our site which may be used to enhance your profile on their site or contribute to the data they hold for various purposes outlined in their respective privacy policies.
 
 ## Questions and complaints
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,13 +40,11 @@ const config = {
           changefreq: 'weekly',
           priority: 0.5,
         },
-        gtag: {
-          trackingID: 'G-6PG193J31V',
-          anonymizeIP: true,
-        },
       }),
     ],
   ],
+
+  plugins: ['docusaurus-plugin-umami'],
 
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
@@ -165,6 +163,10 @@ const config = {
         apiKey: 'f54157cf9bcb7564a29aa0995e0eb192',
         indexName: 'docs-sodaforsparc',
         contextualSearch: true,
+      },
+      umami: {
+        websiteid: '4dfba05a-4a76-4d20-92b4-a7778613dbb0',
+        src: 'https://umami.fairdataihub.org/mushroom.js',
       },
     }),
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@svgr/webpack": "6.3.1",
     "axios": "0.27.2",
     "clsx": "1.2.1",
+    "docusaurus-plugin-umami": "^2.0.0",
     "express": "4.18.1",
     "file-loader": "6.2.0",
     "prism-react-renderer": "1.3.5",

--- a/src/theme/Footer/index.jsx
+++ b/src/theme/Footer/index.jsx
@@ -1,10 +1,7 @@
 /* eslint-disable max-len */
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 // eslint-disable-next-line import/no-unresolved
 import Link from '@docusaurus/Link';
-import Lottie from 'react-lottie';
-import { useCookies } from 'react-cookie';
-import CookiesLottieJSON from './cookies.json';
 
 export function ExternalLinkSVG() {
   return (
@@ -26,31 +23,6 @@ export function ExternalLinkSVG() {
 }
 
 export default function FooterWrapper() {
-  const animationOptions = {
-    loop: true,
-    autoplay: true,
-    animationData: CookiesLottieJSON,
-    rendererSettings: {
-      preserveAspectRatio: 'xMidYMid slice',
-    },
-  };
-
-  const [showCookieBanner, setShowCookieBanner] = useState(false);
-  const [cookies, setCookie] = useCookies(['cookieConsent']);
-
-  const handleCookieBannerClose = () => {
-    setShowCookieBanner(false);
-    setCookie('cookieConsent', true, { path: '/', maxAge: 60 * 60 * 24 * 60 });
-  };
-
-  useEffect(() => {
-    if (cookies.cookieConsent) {
-      setShowCookieBanner(false);
-    } else {
-      setShowCookieBanner(true);
-    }
-  }, [cookies]);
-
   return (
     <div>
       <footer className="bg-[color:var(--footer-background-color)]">
@@ -491,29 +463,6 @@ export default function FooterWrapper() {
               </a>
             </div>
           </div>
-          {/* Cookie notification container */}
-          {showCookieBanner && (
-            <div className="fixed bottom-20 right-3 hidden max-w-[280px] scale-95 rounded-lg border-2 border-green-200 bg-zinc-50 shadow-md  transition-all hover:scale-100 hover:shadow-xl sm:flex">
-              <div className="mb-2 flex flex-col items-center justify-center py-2 px-4">
-                <Lottie options={animationOptions} height={150} width={150} />
-                <p className="mb-1 text-left text-sm text-gray-600">
-                  We use cookies to understand how you use our website and make your experience
-                  better.
-                </p>
-                <p className="mb-3 text-left text-sm text-gray-600">
-                  To find out more read our <Link href="/docs/privacypolicy">privacy policy</Link>{' '}
-                  and <Link href="/docs/cookiepolicy">cookie policy</Link>.
-                </p>
-                <button
-                  className="cookie-button cookie-button-yes !text-base"
-                  onClick={handleCookieBannerClose}
-                  type="button"
-                >
-                  Okay, I Agree
-                </button>
-              </div>
-            </div>
-          )}
         </div>
       </footer>
     </div>

--- a/versioned_docs/version-7.0.1/cookiepolicy.md
+++ b/versioned_docs/version-7.0.1/cookiepolicy.md
@@ -8,46 +8,17 @@ image: https://docs.sodaforsparc.io/thumbnails/base/cookiepolicy.png
 
 ## What Are Cookies?
 
-As is common practice with almost all professional websites this site uses cookies, which are tiny files that are downloaded to your computer, to improve your experience. This page describes what information they gather, how we use it and why we sometimes need to store these cookies. We will also share how you can prevent these cookies from being stored however this may downgrade or 'break' certain elements of the sites functionality.
+A cookie is a file that is downloaded to a device (computer or mobile phone) when accessing certain web pages. Cookies allow a web page, among other things, to store and retrieve information about the browsing habits of a user or a computer and, depending on the information they contain and the way they use their equipment, they can be used to recognize to user.
 
 For more information, please visit [AllAboutCookies.org](https://www.allaboutcookies.org/).
 
 ## How We Use Cookies
 
-We use cookies for a variety of reasons detailed below. Unfortunately in most cases there are no industry standard options for disabling cookies without completely disabling the functionality and features they add to this site. It is recommended that you leave on all cookies if you are not sure whether you need them or not in case they are used to provide a service that you use.
+We do not use third-party cookies or send any information to third-parties. We do collect website usage information via the privacy focused, self hosted and open source [Umami](https://umami.is/) platform. Umami lets us gather the data you need while respecting your privacy. Umami does not collect any personal information, does not use cookies, does not track users across websites, and is GDPR compliant. All data collected is anonymized, making it impossible to identify any individual user. To see exactly what information we collect you can preview our public dashboard [here](https://umami.fairdataihub.org/share/IgtWDN0v/docs.sodaforsparc.io).
 
-## Disabling Cookies
-
-At the moment we do not have the functionality to disable cookies from the website. In order to prevent any tracking by third party analysis and measurement tools we use, please follow the steps provided below for your specific browser.
-
-## Find out how to manage cookies on popular browsers
-
-- [Google Chrome](https://support.google.com/accounts/answer/61416)
-- [Mozilla Firefox](https://support.mozilla.org/en-US/kb/enable-and-disable-cookies-website-preferences)
-- [Apple Safari](https://support.apple.com/en-gb/guide/safari/sfri11471/mac)
-- [Microsoft Edge](https://support.microsoft.com/sr-latn-rs/help/4468242/microsoft-edge-browsing-data-and-privacy-microsoft-privacy)
-- [Microsoft Internet Explorer](https://support.microsoft.com/en-gb/help/17442/windows-internet-explorer-delete-manage-cookies)
-- [Opera](https://help.opera.com/en/latest/web-preferences/#cookies)
-
-To find information relating to other browsers, visit the browser developer's website.
-
-To opt-out of being tracked by Google Analytics across all websites, visit http://tools.google.com/dlpage/gaoptout
-
-You can also visit the trade body representing these advertising platforms for more information: [Network Advertising Initiative](https://www.networkadvertising.org/choices/;).
+## Additional Information
 
 When you access third party sites on our Sites, or when you are reading integration or social media links, cookies can be created by the companies disseminating these links. These third parties may be able to use cookies in the context of Fair Data Innovations Hub's Services (partners or other third parties supplying content or services available on the Fair Data Innovations Hub site) and are responsible for the cookies they install, and it is their conditions on cookies which apply. For more information, you are advised to check the cookie policy directly on these third-party sites concerning their use of cookies.
-
-## The Cookies We Set
-
-Site preferences cookies - In order to provide you with a great experience on this site we provide the functionality to set your preferences for how this site runs when you use it. In order to remember your preferences we need to set cookies so that this information can be called whenever you interact with a page is affected by your preferences.
-##Third Party Cookies
-In some special cases we also use cookies provided by trusted third parties. The following section details which third party cookies you might encounter through this site.
-
-- This site uses Google Analytics which is one of the most widespread and trusted analytics solution on the web for helping us to understand how you use the site and ways that we can improve - your experience. These cookies may track things such as how long you spend on the site and the pages that you visit so we can continue to produce engaging content. For more information on Google Analytics cookies, see the official [Google Analytics](https://policies.google.com/privacy?hl=en-US) page.
-- Third party analytics are used to track and measure usage of this site so that we can continue to produce engaging content. These cookies may track things such as how long you spend on the - site or pages you visit which helps us to understand how we can improve the site for you.
-- From time to time we test new features and make subtle changes to the way that the site is delivered. When we are still testing new features these cookies may be used to ensure that you - receive a consistent experience whilst on the site whilst ensuring we understand which optimisations our users appreciate the most.
-- As we sell products it's important for us to understand statistics about how many of the visitors to our site actually make a purchase and as such this is the kind of data that these cookies - will track. This is important to you as it means that we can accurately make business predictions that allow us to monitor our advertising and product costs to ensure the best possible price.
-- We also use social media buttons and/or plugins on this site that allow you to connect with your social network in various ways. For these to work the following social media sites including - Twitter, Facebook, Instagram, etc., will set cookies through our site which may be used to enhance your profile on their site or contribute to the data they hold for various purposes outlined in their respective privacy policies.
 
 ## Questions and complaints
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6608,6 +6608,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+docusaurus-plugin-umami@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-umami/-/docusaurus-plugin-umami-2.0.0.tgz#c9918484423c6e5c342cbbb05b22448055b78560"
+  integrity sha512-SgkZZYuUMCZe0XeitTA2RPVJvb4fC3aiF3pHc1JxEoaeF9v5g34Yxr2YQb18eFhAMeVK4AjjCr62IwpnuOGyEg==
+
 dom-converter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"


### PR DESCRIPTION
Moving to umami removes the need to show a cookie notice. We are more user privacy-focused and GDPR compliant with this move. 