### PR TITLE
feat: ✨ add 'SODA' to the versioning label

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-dom": "18.2.0",
     "react-lottie": "1.2.3",
     "react-player": "2.10.1",
+    "semver": "^7.3.7",
     "url-loader": "4.1.1",
     "uuid": "8.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "react-dom": "18.2.0",
     "react-lottie": "1.2.3",
     "react-player": "2.10.1",
-    "semver": "^7.3.7",
     "url-loader": "4.1.1",
     "uuid": "8.3.2"
   },

--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -1,0 +1,75 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable react/jsx-props-no-spreading */
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { useVersions, useActiveDocContext } from '@docusaurus/plugin-content-docs/client';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { useDocsPreferredVersion } from '@docusaurus/theme-common';
+import { useDocsVersionCandidates } from '@docusaurus/theme-common/internal';
+import { translate } from '@docusaurus/Translate';
+import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
+import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';
+import semver from 'semver';
+
+const getVersionMainDoc = (version) => version.docs.find((doc) => doc.id === version.mainDocId);
+export default function DocsVersionDropdownNavbarItem({
+  mobile,
+  docsPluginId,
+  dropdownActiveClassDisabled,
+  dropdownItemsBefore,
+  dropdownItemsAfter,
+  ...props
+}) {
+  const activeDocContext = useActiveDocContext(docsPluginId);
+  const versions = useVersions(docsPluginId);
+  const { savePreferredVersionName } = useDocsPreferredVersion(docsPluginId);
+  const versionLinks = versions.map((version) => {
+    // We try to link to the same doc, in another version
+    // When not possible, fallback to the "main doc" of the version
+    const versionDoc =
+      activeDocContext.alternateDocVersions[version.name] ?? getVersionMainDoc(version);
+    return {
+      label: `${semver.valid(version.label) ? 'SODA v.' : ''}${version.label}`,
+      to: versionDoc.path,
+      isActive: () => version === activeDocContext.activeVersion,
+      onClick: () => savePreferredVersionName(version.name),
+    };
+  });
+  const items = [...dropdownItemsBefore, ...versionLinks, ...dropdownItemsAfter];
+  const dropdownVersion = useDocsVersionCandidates(docsPluginId)[0];
+  // Mobile dropdown is handled a bit differently
+  const dropdownLabel =
+    mobile && items.length > 1
+      ? translate({
+          id: 'theme.navbar.mobileVersionsDropdown.label',
+          message: 'Versions',
+          description: 'The label for the navbar versions dropdown on mobile view',
+        })
+      : `${semver.valid(dropdownVersion.label) ? 'SODA v.' : ''}${dropdownVersion.label}`;
+  const dropdownTo =
+    mobile && items.length > 1 ? undefined : getVersionMainDoc(dropdownVersion).path;
+  // We don't want to render a version dropdown with 0 or 1 item. If we build
+  // the site with a single docs version (onlyIncludeVersions: ['1.0.0']),
+  // We'd rather render a button instead of a dropdown
+  if (items.length <= 1) {
+    return (
+      <DefaultNavbarItem
+        {...props}
+        mobile={mobile}
+        label={dropdownLabel}
+        to={dropdownTo}
+        isActive={dropdownActiveClassDisabled ? () => false : undefined}
+      />
+    );
+  }
+  return (
+    <DropdownNavbarItem
+      {...props}
+      mobile={mobile}
+      label={dropdownLabel}
+      to={dropdownTo}
+      items={items}
+      isActive={dropdownActiveClassDisabled ? () => false : undefined}
+    />
+  );
+}

--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -9,7 +9,6 @@ import { useDocsVersionCandidates } from '@docusaurus/theme-common/internal';
 import { translate } from '@docusaurus/Translate';
 import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
 import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';
-import semver from 'semver';
 
 const getVersionMainDoc = (version) => version.docs.find((doc) => doc.id === version.mainDocId);
 export default function DocsVersionDropdownNavbarItem({
@@ -29,7 +28,7 @@ export default function DocsVersionDropdownNavbarItem({
     const versionDoc =
       activeDocContext.alternateDocVersions[version.name] ?? getVersionMainDoc(version);
     return {
-      label: `${semver.valid(version.label) ? 'SODA v.' : ''}${version.label}`,
+      label: `${version.label === 'Upcoming 🚧' ? '' : 'SODA v.'}${version.label}`,
       to: versionDoc.path,
       isActive: () => version === activeDocContext.activeVersion,
       onClick: () => savePreferredVersionName(version.name),
@@ -45,7 +44,7 @@ export default function DocsVersionDropdownNavbarItem({
           message: 'Versions',
           description: 'The label for the navbar versions dropdown on mobile view',
         })
-      : `${semver.valid(dropdownVersion.label) ? 'SODA v.' : ''}${dropdownVersion.label}`;
+      : `${dropdownVersion.label === 'Upcoming 🚧' ? '' : 'SODA v.'}${dropdownVersion.label}`;
   const dropdownTo =
     mobile && items.length > 1 ? undefined : getVersionMainDoc(dropdownVersion).path;
   // We don't want to render a version dropdown with 0 or 1 item. If we build


### PR DESCRIPTION
Should make the distinction between `docs version` and `app version` more clear. The new display format is only on the front end so all the files, labels and paths in the back end are not modified. 