### PR TITLE
Link updates and project setup details

### DIFF
--- a/docs/common-errors/installing-the-pennsieve-agent.md
+++ b/docs/common-errors/installing-the-pennsieve-agent.md
@@ -10,7 +10,7 @@ image: https://og.fairdataihub.org/api/ogimage?app=soda-for-sparc&title=Installi
 
 ## Solution
 
-You can follow the [instructions provided here](https://docs.pennsieve.io/docs/the-pennsieve-agent) to install the Pennsieve agent. For any other questions, please visit the dedicated [Pennsieve Documentation](https://docs.pennsieve.io/docs).
+You can follow the [instructions provided here](https://docs.pennsieve.io/v1/docs/the-pennsieve-agent) to install the Pennsieve agent. For any other questions, please visit the dedicated [Pennsieve Documentation](https://docs.pennsieve.io/docs).
 
 import PageFeedback from '@site/src/components/PageFeedback';
 

--- a/docs/developer-documentation/building-the-application.md
+++ b/docs/developer-documentation/building-the-application.md
@@ -7,7 +7,6 @@ image: https://og.fairdataihub.org/api/ogimage?app=soda-for-sparc&title=Building
 
 ```shell title="For Windows"
 conda activate env-electron-python
-cd ./src
 npm run python-onefile-build
 
 # To build only
@@ -19,7 +18,6 @@ npm run deploy-win
 
 ```shell title="For macOS"
 conda activate env-electron-python
-cd ./src
 npm run python-onefile-build
 
 # To build only
@@ -31,7 +29,6 @@ npm run deploy-mac
 
 ```shell title="For Linux"
 conda activate env-electron-python
-cd ./src
 npm run python-onefile-build
 
 # To build only

--- a/docs/developer-documentation/project-setup.md
+++ b/docs/developer-documentation/project-setup.md
@@ -29,25 +29,19 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 ```shell title="For Windows"
-cd ./tools/anaconda-env
-conda env create -f environment-Windows.yml
-cd ../src/
+conda env create -f ./tools/anaconda-env/environment-Windows.yml
 conda activate env-electron-python
 npm install
 ```
 
 ```shell title="For macOS"
-cd ./tools/anaconda-env
-conda env create -f environment-MAC.yml
-cd ../src/
+conda env create -f ./tools/anaconda-env/environment-MAC.yml
 conda activate env-electron-python
 npm install
 ```
 
 ```shell title="For linux"
-cd ./tools/anaconda-env
-conda env create -f environment-Linux.yml
-cd ../src/
+conda env create -f ./tools/anaconda-env/environment-Linux.yml
 conda activate env-electron-python
 npm install
 ```

--- a/docs/how-to/how-to-get-your-data-deliverables-document.md
+++ b/docs/how-to/how-to-get-your-data-deliverables-document.md
@@ -11,7 +11,7 @@ The milestones and associated datasets as agreed between awardees and SPARC are 
 
 ## How to
 
-To obtain the Data Deliverables document associated with your award, simply ask your PI or grant manager. [Download a template](https://github.com/fairdataihub/SODA-for-SPARC/blob/main/src/file_templates/DataDeliverablesDocument-template.docx?raw=true) of the Data Deliverables document to see the expected format. A screenshot of a sample Dataset Deliverables document is provided below. Most importantly, it should be in the docx format and at least one table should be included with these exact three headers: `Related milestone, aim, or task`, `Description of data`, `Expected date of completion`. Make sure these three headers are spelled correctly for SODA to recognize your Data Deliverables document.
+To obtain the Data Deliverables document associated with your award, simply ask your PI or grant manager. [Download a template](https://github.com/fairdataihub/SODA-for-SPARC/blob/main/file_templates/DataDeliverablesDocument-template.docx?raw=true) of the Data Deliverables document to see the expected format. A screenshot of a sample Dataset Deliverables document is provided below. Most importantly, it should be in the docx format and at least one table should be included with these exact three headers: `Related milestone, aim, or task`, `Description of data`, `Expected date of completion`. Make sure these three headers are spelled correctly for SODA to recognize your Data Deliverables document.
 
 ![](https://github.com/fairdataihub/SODA-for-SPARC/blob/main/docs/documentation/How%20to/submission/data-deliverables-doc-example.PNG?raw=true)
 


### PR DESCRIPTION
Instructions were with /src folder and that has been removed so just updating the text on the documentation. Links for downloading the Pennsieve Agent (v1) has been updated as well as the download link to download a data deliverable file