### PR TITLE
feat: ✨ api version mismatch page

### DIFF
--- a/docs/common-errors/api-version-mismatch.md
+++ b/docs/common-errors/api-version-mismatch.md
@@ -1,0 +1,27 @@
+---
+sidebar_position: 6
+title: API Version Mismatch
+image: https://og.fairdataihub.org/api/ogimage?app=soda-for-sparc&title=API%20Version%20Mismatch&description=Common%20errors%20and%20their%20solutions
+---
+
+## Issue Background
+
+Upon downloading/auto-updating the old server was never replaced by the most up to date server.
+
+## Solution
+
+**This solution is for Linux users only.**
+
+1. Check if there is a server running in the background by typing `app` in the `System Monitor` and ending this process.
+2. Uninstall/remove the SODA AppImage by deleting it.
+3. Download and reinstall [SODA](https://github.com/fairdataihub/SODA-for-SPARC/releases/download/v12.0.2/SODA-for-SPARC-12.0.2.AppImage)
+
+Sometimes upon following this process and reinstalling SODA the same issue appears. This can happen when the `app` process does not appear in the System Monitor even though
+it is running in the background. If this happens you can use the following terminal commands in lieu of step 1 to find the `app` process and end it before completing steps 2 and 3:
+
+1. Check for the server by running this command in the terminal: `lsof -i:4242`
+   - If there is a result ( not an empty console ) then end the 'app' service by running this command in the terminal: `kill -9 <pid>`
+
+import PageFeedback from '@site/src/components/PageFeedback';
+
+<PageFeedback />

--- a/versioned_docs/version-12.1.0/common-errors/api-version-mismatch.md
+++ b/versioned_docs/version-12.1.0/common-errors/api-version-mismatch.md
@@ -1,0 +1,27 @@
+---
+sidebar_position: 6
+title: API Version Mismatch
+image: https://og.fairdataihub.org/api/ogimage?app=soda-for-sparc&title=API%20Version%20Mismatch&description=Common%20errors%20and%20their%20solutions
+---
+
+## Issue Background
+
+Upon downloading/auto-updating the old server was never replaced by the most up to date server.
+
+## Solution
+
+**This solution is for Linux users only.**
+
+1. Check if there is a server running in the background by typing `app` in the `System Monitor` and ending this process.
+2. Uninstall/remove the SODA AppImage by deleting it.
+3. Download and reinstall [SODA](https://github.com/fairdataihub/SODA-for-SPARC/releases/download/v12.0.2/SODA-for-SPARC-12.0.2.AppImage)
+
+Sometimes upon following this process and reinstalling SODA the same issue appears. This can happen when the `app` process does not appear in the System Monitor even though
+it is running in the background. If this happens you can use the following terminal commands in lieu of step 1 to find the `app` process and end it before completing steps 2 and 3:
+
+1. Check for the server by running this command in the terminal: `lsof -i:4242`
+   - If there is a result ( not an empty console ) then end the 'app' service by running this command in the terminal: `kill -9 <pid>`
+
+import PageFeedback from '@site/src/components/PageFeedback';
+
+<PageFeedback />

--- a/versioned_docs/version-12.1.0/common-errors/sending-log-files-to-soda-team.md
+++ b/versioned_docs/version-12.1.0/common-errors/sending-log-files-to-soda-team.md
@@ -20,11 +20,19 @@ To automatically gather your log files:
 
 ### Manually
 
-You can also get the log files manually. Here are their locations on the different OS:
+You can also get the log files manually. There are two locations where log files are stored. The first location is the log files for the Electron process. THe second location stores log files for the SODA server. When possible, both should be gathered and sent to the SODA team.
+
+#### Electron Process Log Files
 
 1. Windows: _C:\Users\your-username\AppData\Roaming\SODA for SPARC\logs_
 2. macOS: _~/your-username/Library/Logs/SODA_
 3. Ubuntu: _/home/your-username/.config/SODA/logs_
+
+#### SODA Server Log Files
+
+1. Windows: C:\Users\your-username\SODA\logs
+2. macOS: ~/your-username/SODA/logs
+3. Ubuntu: /home/your-username/SODA/logs
 
 ### Common issues regarding the log files
 


### PR DESCRIPTION
This common error page is for Linux users who auto-update and never have the old server replaced by the most up to date server.